### PR TITLE
Changed number of first ADR to 0001

### DIFF
--- a/cypress/integration/adrManagerTest/PushNewAdr.js
+++ b/cypress/integration/adrManagerTest/PushNewAdr.js
@@ -39,7 +39,7 @@ context("Test commit and push file --> delete file in repo (push)", () => {
 
        // Add new file
        cy.get('[data-cy=NewAdrFile]').click({force: true});
-       cy.contains('0000-*').click();
+       cy.contains('0001-*').click();
        cy.get('[data-cy=pushIcon]').click();
        
        // Check dialog commit & push

--- a/cypress/integration/adrManagerTest/Routing.js
+++ b/cypress/integration/adrManagerTest/Routing.js
@@ -49,7 +49,7 @@ context("Test for correct URLs", () => {
         cy.get('[data-cy=newADR]').click({force: true});
 
         // With an opened ADR, the URL should contain: full name, branch, adr name.
-        cy.url().should('equal', "http://localhost:8080/#/manager/researchproject2020/ResearchProject/main/0000-.md");
+        cy.url().should('equal', "http://localhost:8080/#/manager/researchproject2020/ResearchProject/main/0001-.md");
 
         cy.get('[data-cy=adrList]').contains('ResearchProject').should('have.length', 0);
 

--- a/src/plugins/store.js
+++ b/src/plugins/store.js
@@ -251,7 +251,7 @@ export const store = new Vue({
       if (this.addedRepositories.includes(repo)) {
         let adr = ArchitecturalDecisionRecord.createNewAdr();
         let md = adr2md(adr);
-        let id = Math.max(...repo.adrs.map((adr) => adr.id), -1) + 1;
+        let id = Math.max(...repo.adrs.map((adr) => adr.id), 0) + 1;
         let newAdr = {
           originalMd: "",
           editedMd: md,


### PR DESCRIPTION
 Change ADR numbering as requested in #92. The first ADR in an empty repository now starts with the number `0001` instead of `0000`.

![grafik](https://user-images.githubusercontent.com/44502936/109948357-8752d700-7cda-11eb-965b-c61c21c67b8b.png)

@koppor I think you already mentioned this before, but please give your approval to this change.